### PR TITLE
Virtualization Update

### DIFF
--- a/pages/schema.md
+++ b/pages/schema.md
@@ -119,7 +119,7 @@ The DCOI Strategic Plan has the following six required elements:
   5. Historical costs, cost savings, and cost avoidances due to data center consolidation and optimization through fiscal year 2015; and
   6. A statement from the agency CIO stating whether the agency has complied with all reporting requirements in this memorandum and the data center requirements of FITARA. If the agency has not complied with all reporting requirements, the agency must provide a statement describing the reasons for not complying.
 
-Parts **1 – 5** above are required to be posted publicly in machine-readable JSON format at **[agencyhomepage].gov/digitalstrategy/datacenteroptimizationstrategicplan.json**. Agency-specific targets can be found at [datacenters.cio.gov](https://datacenters.cio.gov/agency-strategic-plan/). NOTE: In order to assist agencies with compiling these plans, OGP and OMB have developed a tool to convert agencies’ text-based plans to a JSON format for this purpose. This can be found at [https://datacenters.cio.gov/json-conversion-tool/](https://datacenters.cio.gov/json-conversion-tool/).
+Parts **1 – 5** above are required to be posted publicly in machine-readable JSON format at **[agencyhomepage].gov/digitalstrategy/datacenteroptimizationstrategicplan.json**. NOTE: In order to assist agencies with compiling these plans, OGP and OMB have developed a tool to convert agencies’ text-based plans to a JSON format for this purpose. This can be found at [https://datacenters.cio.gov/json-conversion-tool/](https://datacenters.cio.gov/json-conversion-tool/).
 
 Part **6** of agencies’ DCOI Strategic Plans may be fulfilled using one of the two templates given in the document file provided on this page.  These must be filled out, signed by agencies’ CIOs, and submitted via email to the OFCIO@omb.eop.gov inbox, CC’ing the OMB Agency Liaisons, no later than February 15, 2019.
 
@@ -136,12 +136,13 @@ fy19Achieved                    |  Numeric, 0 - 1000               | Yes       |
 fy20Planned                    |  Numeric, 0 - 1000               | Yes       |
 fy20Achieved                    |  Numeric, 0 - 1000               | Yes       |
 explanationForUnmetPlannedValue |  String, 0 - 10000              | No      |
-**virtualization**                        |                        |           | Total count of virtual hosts (servers + mainframes).
+**virtualization**                        |                        |           | Total count of virtual hosts (servers + mainframes). Agencies may report systems under their cloud investments towards this total count to more accurately reflect the state of their virtualized portfolio.
 fy19Planned                    |  Numeric, 0 - 100000               | Yes       |
-fy19PAchieved                    |  Numeric, 0 - 100000               | Yes       |
+fy19Achieved                    |  Numeric, 0 - 100000               | Yes       |
 fy20Planned                    |  Numeric, 0 - 100000               | Yes       |
 fy20Achieved                    |  Numeric, 0 - 100000               | Yes       |
 explanationForUnmetPlannedValue |  String, 0 - 10000              | No      |
+methodology 			|  String, 0 - 10000              | No      | Optional field to explain the methodology your agency used to arrive at the Virtualization metric. If the methodology is different between data centers, please note this in the comments section.
 **underutilizedServers**                        |                        |           | Total count of underutilized servers.
 fy19Planned                    |  Numeric, 0 - 100000               | Yes       |
 fy19Achieved                    |  Numeric, 0 - 100000               | Yes       |
@@ -198,7 +199,8 @@ historicalCostSavings |  String, 5 - 10000              | Yes      |
 			"fy19Planned": 110,
 			"fy19Achieved": 0,
 			"fy20Planned": 120,
-			"fy20Achieved": 0
+			"fy20Achieved": 0,
+			"methodology": "OPTIONAL TEXT"
 		},
 		"underutilizedServers": {
 			"fy19Planned": 100,


### PR DESCRIPTION
added optional methodology section to JSON schema and example file.
Additional changes:
* Fixed 1 small typo as well
* removed:  "Agency-specific targets can be found at [datacenters.cio.gov](https://datacenters.cio.gov/agency-strategic-plan/). " because this is a dead link and no longer relevant based on new policy
* Please also note that the JSON conversion tool at: https://datacenters.cio.gov/json-conversion-tool/ is a dead link as well